### PR TITLE
Fix invalid feature value error message

### DIFF
--- a/src/optimizely-sync-config-validators.ts
+++ b/src/optimizely-sync-config-validators.ts
@@ -38,7 +38,7 @@ function isOptimizelySyncConfig(
         featureValue > 10000
       ) {
         throw new Error(
-          'Feature values must be an integer between 0 and 1000 (inclusive).',
+          'Feature values must be an integer between 0 and 10,000 (inclusive).',
         );
       }
     });


### PR DESCRIPTION
Optimizely feature values allow 2 levels of decimal precision, which means they take number between 0.00 and 100.00, but stored as integers, which means valid inputs should be between 0 and 10,000.

The current code is correct, but the error message was missing a 0.