### PR TITLE
Configure env values when creating a feature

### DIFF
--- a/src/optimizely-sync-config-helpers.test.ts
+++ b/src/optimizely-sync-config-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   getConfigFeatureKeys,
   getOptimizelyFeatureKeys,
   transformOptimizelyFeaturesToSyncConfig,
+  transformValueToRolloutRule,
 } from './optimizely-sync-config-helpers';
 import type { Environment, Feature } from './optimizely-client-types';
 import type { OptimizelySyncConfig } from './optimizely-sync-types';
@@ -274,6 +275,19 @@ describe('optimizely-sync-config-helpers', () => {
           feature_1: 0,
           feature_2: 0,
         },
+      });
+    });
+  });
+
+  describe('transformValueToRolloutRule', () => {
+    it('is a function', () => {
+      expect(typeof transformValueToRolloutRule).toBe('function');
+    });
+    it('returns an RolloutRule', () => {
+      expect(transformValueToRolloutRule(1234)).toEqual({
+        audience_conditions: 'everyone',
+        enabled: true,
+        percentage_included: 1234,
       });
     });
   });

--- a/src/optimizely-sync-config-helpers.ts
+++ b/src/optimizely-sync-config-helpers.ts
@@ -89,3 +89,11 @@ export const transformOptimizelyFeaturesToSyncConfig = (
 
   return config;
 };
+
+export const transformValueToRolloutRule = (value: number): RolloutRule => {
+  return {
+    audience_conditions: 'everyone',
+    enabled: true,
+    percentage_included: value,
+  };
+};

--- a/src/optimizely-sync.test.ts
+++ b/src/optimizely-sync.test.ts
@@ -108,9 +108,44 @@ describe('optimizely-sync', () => {
         features,
       );
 
+      const expectedArg1: PartialFeature = {
+        key: 'someFeature',
+        environments: {
+          someEnv: {
+            rollout_rules: [
+              {
+                audience_conditions: 'everyone',
+                enabled: true,
+                percentage_included: 10000,
+              },
+            ],
+          },
+        },
+      };
+      const expectedArg2: PartialFeature = {
+        key: 'otherFeature',
+        environments: {
+          someEnv: {
+            rollout_rules: [
+              {
+                audience_conditions: 'everyone',
+                enabled: true,
+                percentage_included: 5000,
+              },
+            ],
+          },
+        },
+      };
+
       expect(consoleLog).toBeCalledTimes(2);
       // There are two features so it should run twice
       expect(mockedOptimizelyClient.createFeature).toBeCalledTimes(2);
+      expect(mockedOptimizelyClient.createFeature).toHaveBeenCalledWith(
+        expectedArg1,
+      );
+      expect(mockedOptimizelyClient.createFeature).toHaveBeenCalledWith(
+        expectedArg2,
+      );
 
       consoleLog.mockRestore();
     });

--- a/src/optimizely-sync.ts
+++ b/src/optimizely-sync.ts
@@ -5,6 +5,7 @@ import {
   findUnconfiguredFeatures,
   findUndeployedFeatures,
   transformOptimizelyFeaturesToSyncConfig,
+  transformValueToRolloutRule,
 } from './optimizely-sync-config-helpers';
 import { OptimizelySyncConfig } from './optimizely-sync-types';
 import { Feature } from './optimizely-client-types';
@@ -105,11 +106,7 @@ export async function persistFeatures(
               envName,
               {
                 rollout_rules: [
-                  {
-                    audience_conditions: 'everyone',
-                    enabled: true,
-                    percentage_included: config[envName][feature.key],
-                  },
+                  transformValueToRolloutRule(config[envName][feature.key]),
                 ],
               },
             ];


### PR DESCRIPTION
Previously this would create the feature, but not set any values.  And since `persistFeatures` loops over the deployed features, not the configured ones, it was not configured there either.

Since it could be possible that we would want to create a feature, and not change any others, it makes sense to configure it at creation time.

Fixes #14.